### PR TITLE
Revert "Fix | Fixing Cross-site Scripting in djangorestframework"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # requirements.txt
 
 Django>=3.2.4,<3.3
-djangorestframework==3.15.2
+djangorestframework>=3.12.4,<3.13
 psycopg2-binary>=2.8.6
 drf-spectacular>=0.15.1,<0.16


### PR DESCRIPTION
Reverting changes made in PR moosasharieff/Cookbook#11 as GitHub Actions failed for the following [error](https://github.com/moosasharieff/Cookbook/actions/runs/10511056639/job/29121129833) :

```
10.15 The conflict is caused by:
10.15     The user requested Django<3.3 and >=3.2.4
10.15     djangorestframework 3.15.2 depends on django>=4.2
```