### PR TITLE
Fix | Fixing Swagger UI API Documentation rendering issue.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # requirements.txt
 
 Django>=4.2.15
-djangorestframework==3.15.2
+djangorestframework>=3.15.2,<3.16
 psycopg2-binary>=2.8.6
-drf-spectacular>=0.15.1,<0.16
+drf-spectacular>=0.27.2,<0.28


### PR DESCRIPTION
- After upgrading to Django>=4.2.15, Swagger UI to render API Documentation stopped working and starting giving out error. Upgraded and limited 'djangorestframework' and 'drf-spectacular' to a compatible and particular version.
- Ran act library to test GitHub Actions locally and everything is good.
- Tested and validated the Swagger UI is working as expected and we can test our APIs too.